### PR TITLE
Adds restart function to issue restart to repl

### DIFF
--- a/autoload/scheme.vim
+++ b/autoload/scheme.vim
@@ -45,3 +45,11 @@ function! scheme#eval(type)
   let &selection = sel_save
   let @@ = reg_save
 endfunction
+
+function! scheme#restart()
+  if has("nvim")
+    call jobsend(s:repl_term_id, "(RESTART 1)\n")
+  else
+    call term_sendkeys(s:repl_term_id, "(RESTART 1)\n")
+  end
+endfunction

--- a/plugin/scheme.vim
+++ b/plugin/scheme.vim
@@ -4,3 +4,4 @@ let g:scheme_split_size = get(g:, "scheme_split_size", "default")
 
 autocmd FileType scheme,racket nnoremap <buffer> cp :set opfunc=scheme#eval<cr>g@
 autocmd FileType scheme,racket nnoremap <buffer> cpp :normal cpaf<cr>
+autocmd FileType scheme,racket nnoremap <buffer> crr :call scheme#restart()<cr>


### PR DESCRIPTION
Adds scheme#restart autoload function. Adds `crr` binding to easily send
restart to the repl to clear a current error state and return to the top
level of the repl to continue evaluating forms.

E.g. Evaluate a form that throws an error in the repl, issue `crr` and return to the top level out of the error state.